### PR TITLE
Push floats as uint32 on RPDO topic.

### DIFF
--- a/canopen_base_driver/src/lely_driver_bridge.cpp
+++ b/canopen_base_driver/src/lely_driver_bridge.cpp
@@ -160,6 +160,12 @@ void LelyDriverBridge::OnRpdoWrite(uint16_t idx, uint8_t subidx) noexcept
     sub->setVal<CO_DEFTYPE_INTEGER32>((int32_t)rpdo_mapped[idx][subidx]);
     std::memcpy(&data, &sub->getVal<CO_DEFTYPE_INTEGER32>(), 4);
   }
+  if (co_def == CO_DEFTYPE_REAL32)
+  {
+    std::scoped_lock<std::mutex> lck(this->dictionary_mutex_);
+    sub->setVal<CO_DEFTYPE_REAL32>((float_t)rpdo_mapped[idx][subidx]);
+    std::memcpy(&data, &sub->getVal<CO_DEFTYPE_REAL32>(), 4);
+  }
   COData codata = {idx, subidx, data};
 
   //  We do not care so much about missing a message, rather push them through.


### PR DESCRIPTION
Required to get floating-point values from our drives.

Still limited by the `uint32_t` datatype of `COData` [here](https://github.com/Pliant-Energy/ros2_canopen/blob/dz/jazzy-custom/canopen_core/include/canopen_core/exchange.hpp#L30) but we can convert downstream of the driver. 